### PR TITLE
Inform user of expired tokens

### DIFF
--- a/spotify_telegram_sync/bot.py
+++ b/spotify_telegram_sync/bot.py
@@ -10,16 +10,15 @@ from collections import namedtuple
 from string import punctuation
 from typing import Dict, List, Optional, Union
 
+import constants
 import httpx
 import tekore as tk
+from database import Database
+from get_song_file import DeezLoader, InvalidTokenError
 from telethon import TelegramClient, errors, events, tl, types
 from telethon.sessions import StringSession
 from telethon.tl.functions.account import UpdateProfileRequest
 from telethon.tl.functions.users import GetFullUserRequest
-
-import constants
-from database import Database
-from get_song_file import DeezLoader
 
 log_level = logging.getLevelName(os.environ.get("LOG_LEVEL", "INFO"))
 log_format = "%(name)s - %(levelname)s - %(message)s"
@@ -475,11 +474,19 @@ async def update_playlist(
 
         # download each track and send it to the Telegram channel
         deezer = DeezLoader(constants.DEEZER_ARL_TOKEN)
+
         for track in to_be_added:
             logger.debug("Downloading %s", track[0])
             file = None
             try:
                 file = await deezer.from_spotify(isrc=track[2])
+            except InvalidTokenError as e:
+                msg = (
+                    "Your Deezer ARL token is expired/invalid. "
+                    "Replaced it with a new one."
+                )
+                telegram.send_message("me", msg)
+                raise e
             except Exception as e:
                 logger.error(
                     "Couldn't download track %s. Reason: %s",

--- a/spotify_telegram_sync/bot.py
+++ b/spotify_telegram_sync/bot.py
@@ -575,7 +575,16 @@ async def prepare_clients(
         cred = tk.RefreshingCredentials(
             constants.SPOTIFY_CLIENT_ID, constants.SPOTIFY_CLIENT_SECRET
         )
-        token = cred.refresh_user_token(constants.SPOTIFY_REFRESH_TOKEN)
+        try:
+            token = cred.refresh_user_token(constants.SPOTIFY_REFRESH_TOKEN)
+        except tk.BadRequest as e:
+            if "invalid_grant" in str(e):
+                msg = (
+                    "Your Spotify refresh token is expired. "
+                    f"Replace it with a new one. Original error message: '{str(e)}'"
+                )
+                telegram.send_message("me", msg)
+                exit(msg)
         spotify = tk.Spotify(token, asynchronous=True)
         clients["spotify"] = spotify
         logger.debug("Spotify is ready.")

--- a/spotify_telegram_sync/get_song_file.py
+++ b/spotify_telegram_sync/get_song_file.py
@@ -24,6 +24,10 @@ qualities = {
 valid_id3_tags = list(EasyID3.valid_keys.keys())
 
 
+class InvalidTokenError(Exception):
+    """Exception for invalid/expired tokens"""
+
+
 class Sender:
     """Sends requests to the GeniusT Recommender."""
 
@@ -216,7 +220,10 @@ class DeezLoader:
         return res["results"]
 
     async def _download(self, quality: str, data: Dict[str, str]) -> BytesIO:
-        token = (await self._send_private_request("deezer.getUserData"))["checkForm"]
+        token_data = await self._send_private_request("deezer.getUserData")
+        if token_data["USER"]["USER_ID"] == 0:
+            raise InvalidTokenError("ARL token expired/invalid.")
+        token = token_data["checkForm"]
         ids = data["link"].split("?utm")[0].split("/")[-1]
         output = BytesIO()
         infos = await self._send_private_request("song.getData", token, {"sng_id": ids})

--- a/spotify_telegram_sync/server.py
+++ b/spotify_telegram_sync/server.py
@@ -2,10 +2,9 @@ import asyncio
 import logging
 
 import uvicorn
-from fastapi import FastAPI
-
 from bot import prepare_clients, update_playlist
 from constants import PORT
+from fastapi import FastAPI
 
 app = FastAPI()
 logger = logging.getLogger("sts.server")


### PR DESCRIPTION
This PR will add informing the user of expired/invalid Spotify and Deezer ARL tokens. It will send a message using to the user's saved messages about the token and then exit/raise accordingly.